### PR TITLE
Update setup scripts

### DIFF
--- a/copyright
+++ b/copyright
@@ -1,0 +1,27 @@
+Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: python-qosf
+Source: https://github.com/dschreij/QOpenScienceFramework
+
+Files: *
+Copyright: Copyright 2016 Daniel Schreij <dschreij@gmail.com>
+License: GPL-3+
+ This program is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later
+ version.
+ .
+ This program is distributed in the hope that it will be
+ useful, but WITHOUT ANY WARRANTY; without even the implied
+ warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ PURPOSE.  See the GNU General Public License for more
+ details.
+ .
+ You should have received a copy of the GNU General Public
+ License along with this package; if not, write to the Free
+ Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ Boston, MA  02110-1301 USA
+ .
+ On Debian systems, the full text of the GNU General Public
+ License version 3 can be found in the file
+ `/usr/share/common-licenses/GPL-3'.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -5,21 +5,6 @@ import glob
 import QOpenScienceFramework
 from setuptools import setup
 
-def files(path):
-	l = [fname for fname in glob.glob(path) if os.path.isfile(fname) \
-		and not fname.endswith('.pyc')]
-	print(l)
-	return l
-
-
-def data_files():
-	return [
-		("QOpenScienceFramework",
-			files("QOpenScienceFramework/*")),
-		("QOpenScienceFramework/img",
-			files("QOpenScienceFramework/img/*")),
-		]
-
 setup(
 	name="python-qosf",
 	version=QOpenScienceFramework.__version__,
@@ -45,8 +30,6 @@ setup(
 		'requests_oauthlib',
 		'qtawesome',
 	],
-	include_package_data=False,
+	include_package_data=True,
 	packages = ['QOpenScienceFramework'],
-	data_files=data_files()
 	)
-print(data_files())

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,0 +1,8 @@
+[DEFAULT]
+Source=python-qosf
+Package=python-qosf
+Debian-version=1
+Suite=wily
+Copyright-File=copyright
+Build-Depends=qtpy, arrow, humanize, python-fileinspector, requests_oauthlib, qtawesome
+Depends=qtpy, arrow, humanize, python-fileinspector, requests_oauthlib, qtawesome


### PR DESCRIPTION
Similar to my pull request to `opensesame-osf`. One notable exception here: You don't need the `data_files` key, because everything is packages as `package_data`; that is, all non Python files are stored in the Python package folder, which is not the case for OpenSesame extensions (which go in a special folder).
