### PR TITLE
Fix compatibility with qtpy >= 1.1.0

### DIFF
--- a/QOpenScienceFramework/compat.py
+++ b/QOpenScienceFramework/compat.py
@@ -43,7 +43,7 @@ def safe_encode(s, enc='utf-8', errors='strict'):
 def get_QUrl(url):
 	""" Qt4 doesn url handling a bit different than Qt5, so check for that
 	here."""
-	if QtCore.QT_VERSION_STR < '5':
+	if QtCore.PYQT_VERSION_STR < '5':
 		return QtCore.QUrl.fromEncoded(url)
 	else:
 		return QtCore.QUrl(url)

--- a/QOpenScienceFramework/events.py
+++ b/QOpenScienceFramework/events.py
@@ -30,9 +30,9 @@ class EventDispatcher(QtCore.QObject):
 	a login event, a listener should have the function handle_login."""
 
 	# List of possible events this dispatcher can emit
-	logged_in = QtCore.pyqtSignal()
+	logged_in = QtCore.Signal()
 	""" PyQt Signal emitted when a user just logged in. """
-	logged_out = QtCore.pyqtSignal()
+	logged_out = QtCore.Signal()
 	""" PyQt Signal emitted when a user just logged out. """
 
 	def __init__(self, *args, **kwargs):
@@ -141,7 +141,7 @@ class Notifier(QtCore.QObject):
 		""" Constructor """
 		super(Notifier,self).__init__()
 
-	@QtCore.pyqtSlot('QString', 'QString')
+	@QtCore.Slot('QString', 'QString')
 	def error(self, title, message):
 		""" Show an error message in a 'critical' QMessageBox.
 
@@ -157,7 +157,7 @@ class Notifier(QtCore.QObject):
 			message
 		)
 
-	@QtCore.pyqtSlot('QString', 'QString')
+	@QtCore.Slot('QString', 'QString')
 	def warning(self, title, message):
 		""" Show a warning message in a 'warning' QMessageBox.
 
@@ -173,7 +173,7 @@ class Notifier(QtCore.QObject):
 			message
 		)
 
-	@QtCore.pyqtSlot('QString', 'QString')
+	@QtCore.Slot('QString', 'QString')
 	def info(self, title, message):
 		""" Show an info message in an 'information' QMessageBox.
 
@@ -189,7 +189,7 @@ class Notifier(QtCore.QObject):
 			message
 		)
 
-	@QtCore.pyqtSlot('QString', 'QString')
+	@QtCore.Slot('QString', 'QString')
 	def success(self, title, message):
 		""" Show a success message in a 'success' QMessageBox.
 

--- a/QOpenScienceFramework/loginwindow.py
+++ b/QOpenScienceFramework/loginwindow.py
@@ -35,7 +35,7 @@ class LoginWindow(WebView):
 	""" A Login window for the OSF """
 	
 	# Login event is emitted after successfull login
-	logged_in = QtCore.pyqtSignal()
+	logged_in = QtCore.Signal()
 	""" Event fired when user successfully logged in. """
 
 	def __init__(self, *args, **kwargs):

--- a/QOpenScienceFramework/manager.py
+++ b/QOpenScienceFramework/manager.py
@@ -41,13 +41,13 @@ class ConnectionManager(QtNetwork.QNetworkAccessManager):
 
 	# The maximum number of allowed redirects
 	MAX_REDIRECTS = 5
-	error_message = QtCore.pyqtSignal('QString','QString')
+	error_message = QtCore.Signal('QString','QString')
 	"""PyQt signal to send an error message."""
-	warning_message = QtCore.pyqtSignal('QString','QString')
+	warning_message = QtCore.Signal('QString','QString')
 	"""PyQt signal to send a warning message."""
-	info_message = QtCore.pyqtSignal('QString','QString')
+	info_message = QtCore.Signal('QString','QString')
 	"""PyQt signal to send an info message."""
-	success_message = QtCore.pyqtSignal('QString','QString')
+	success_message = QtCore.Signal('QString','QString')
 	"""PyQt signal to send a success message."""
 
 	# Dictionary holding requests in progress, so that they can be repeated if
@@ -330,7 +330,7 @@ class ConnectionManager(QtNetwork.QNetworkAccessManager):
 			The dialog to send the progress indication to. Will be included in the
 			reply object so that it is accessible in the downloadProgress slot, by
 			calling self.sender().property('progressDialog')
-		abortSignal : QtCore.pyqtSignal
+		abortSignal : QtCore.Signal
 			This signal will be attached to the reply objects abort() slot, so that
 			the operation can be aborted from outside if necessary.
 		*args (optional)
@@ -435,7 +435,7 @@ class ConnectionManager(QtNetwork.QNetworkAccessManager):
 
 		# Sadly, Qt4 and Qt5 show some incompatibility in that QUrl no longer has the
 		# addQueryItem function in Qt5. This has moved to a differen QUrlQuery object
-		if QtCore.QT_VERSION_STR < '5':
+		if QtCore.PYQT_VERSION_STR < '5':
 			postdata = QtCore.QUrl()
 		else:
 			postdata = QtCore.QUrlQuery()
@@ -443,7 +443,7 @@ class ConnectionManager(QtNetwork.QNetworkAccessManager):
 		for varname in data_to_send:
 			postdata.addQueryItem(varname, data_to_send.get(varname))
 		# Convert to QByteArray for transport
-		if QtCore.QT_VERSION_STR < '5':
+		if QtCore.PYQT_VERSION_STR < '5':
 			final_postdata = postdata.encodedQuery()
 		else:
 			final_postdata = safe_encode(postdata.toString(QtCore.QUrl.FullyEncoded))
@@ -481,7 +481,7 @@ class ConnectionManager(QtNetwork.QNetworkAccessManager):
 			The dialog to send the progress indication to. Will be included in the
 			reply object so that it is accessible in the downloadProgress slot, by
 			calling self.sender().property('progressDialog')
-		abortSignal : QtCore.pyqtSignal
+		abortSignal : QtCore.Signal
 			This signal will be attached to the reply objects abort() slot, so that
 			the operation can be aborted from outside if necessary.
 		*args (optional)
@@ -544,7 +544,7 @@ class ConnectionManager(QtNetwork.QNetworkAccessManager):
 			function to call whenever an error occurs. Should be able to accept
 			the reply object as an argument. This function is also called if the
 			operation is aborted by the user him/herself.
-		abortSignal : QtCore.pyqtSignal
+		abortSignal : QtCore.Signal
 			This signal will be attached to the reply objects abort() slot, so that
 			the operation can be aborted from outside if necessary.
 		*args (optional)

--- a/QOpenScienceFramework/widgets/loginwindow.py
+++ b/QOpenScienceFramework/widgets/loginwindow.py
@@ -35,7 +35,7 @@ class LoginWindow(WebView):
 	""" A Login window for the OSF """
 	
 	# Login event is emitted after successfull login
-	logged_in = QtCore.pyqtSignal()
+	logged_in = QtCore.Signal()
 	""" Event fired when user successfully logged in. """
 
 	def __init__(self, *args, **kwargs):

--- a/QOpenScienceFramework/widgets/osfexplorer.py
+++ b/QOpenScienceFramework/widgets/osfexplorer.py
@@ -56,7 +56,7 @@ class OSFExplorer(QtWidgets.QWidget):
 	# The maximum size an image may have to be downloaded for preview
 	preview_size_limit = 1024**2/2.0
 	# Signal that is sent if image preview should be aborted
-	abort_preview = QtCore.pyqtSignal()
+	abort_preview = QtCore.Signal()
 	""" PyQt signal emitted when an image preview is to be aborted. """
 
 	def __init__(self, manager, tree_widget=None, locale='en_us'):

--- a/QOpenScienceFramework/widgets/projecttree.py
+++ b/QOpenScienceFramework/widgets/projecttree.py
@@ -47,7 +47,7 @@ class ProjectTree(QtWidgets.QTreeWidget):
 	in a treeview widget."""
 
 	# Event fired when refresh of tree is finished
-	refreshFinished = QtCore.pyqtSignal()
+	refreshFinished = QtCore.Signal()
 	""" PyQt signal that emits when the tree is completely refreshed. """
 	# Maximum of items to return per request (e.g. files in a folder). OSF 
 	# automatically paginates its results

--- a/QOpenScienceFramework/widgets/userbadge.py
+++ b/QOpenScienceFramework/widgets/userbadge.py
@@ -35,9 +35,9 @@ class UserBadge(QtWidgets.QWidget):
 
 	# Class variables
 	# Login and logout events
-	logout_request = QtCore.pyqtSignal()
+	logout_request = QtCore.Signal()
 	""" PyQt signal to send a logout request. """
-	login_request = QtCore.pyqtSignal()
+	login_request = QtCore.Signal()
 	""" PyQt signal to send a login request. """
 
 	def __init__(self, manager, icon_size=None):

--- a/example.py
+++ b/example.py
@@ -118,7 +118,7 @@ class StandAlone(object):
 if __name__ == "__main__":
 	app = QtWidgets.QApplication(sys.argv)
 
-	print("Using Qt {}".format(QtCore.QT_VERSION_STR))
+	print("Using Qt {}".format(QtCore.PYQT_VERSION_STR))
 
 	# Enable High DPI display with PyQt5
 	if hasattr(QtCore.Qt, 'AA_UseHighDpiPixmaps'):


### PR DESCRIPTION
The following replacements have been done automatically:
- QtCore.pyqtSignal -> QtCore.Signal
- QtCore.pyqtSlot -> QtCore.Slot
- QtCore.QT_VERSION_STR -> QtCore.PYQT_VERSION_STR
  versions are not identical but both indicate whether Qt 4 or 5 is used
