### PR TITLE
dependencies: require at least 0.6 of requests-oauthlib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
 		'arrow',
 		'humanize',
 		'python-fileinspector',
-		'requests-oauthlib',
+		'requests-oauthlib>=0.6',
 		'qtawesome',
 	],
 	include_package_data=True,


### PR DESCRIPTION
Older versions, such 0.4 in the Ubuntu 16.04 repos, give the following error:

```
Traceback (most recent call last):
  File "/home/sebastiaan/git/QOpenScienceFramework/QOpenScienceFramework/widgets/loginwindow.py", line 92, in checkResponse
    self.token = osf.parse_token_from_url(r_url)
  File "/home/sebastiaan/git/QOpenScienceFramework/QOpenScienceFramework/connection.py", line 178, in parse_token_from_url
    if is_authorized():
  File "/home/sebastiaan/git/QOpenScienceFramework/QOpenScienceFramework/connection.py", line 193, in is_authorized
    return session.authorized
```
