### PR TITLE
Fix compatibility with old versions of QtAwesome

### DIFF
--- a/QOpenScienceFramework/__init__.py
+++ b/QOpenScienceFramework/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 __author__ = "Daniel Schreij"
 import os
 import sys
@@ -8,6 +8,3 @@ dirname = safe_decode(os.path.dirname(__file__), enc=sys.getfilesystemencoding()
 import QOpenScienceFramework.manager
 import QOpenScienceFramework.connection
 import QOpenScienceFramework.widgets
-
-
-

--- a/QOpenScienceFramework/widgets/projecttree.py
+++ b/QOpenScienceFramework/widgets/projecttree.py
@@ -383,14 +383,17 @@ class ProjectTree(QtWidgets.QTreeWidget):
         else:
             secondary_icon = None
 
-        if primary_icon:
-            if secondary_icon:
-                return qta.icon(primary_icon, secondary_icon[0], options=[
-                    {}, {'scale_factor': 0.70, 'offset': (
-                        0.2, 0.20), 'color': secondary_icon[1]}
-                ])
-            else:
-                return qta.icon(primary_icon)
+        try:
+            if primary_icon:
+                if secondary_icon:
+                    return qta.icon(primary_icon, secondary_icon[0], options=[
+                        {}, {'scale_factor': 0.70, 'offset': (
+                            0.2, 0.20), 'color': secondary_icon[1]}
+                    ])
+                else:
+                    return qta.icon(primary_icon)
+        except Exception:
+            return QtGui.QIcon.fromTheme('text-x-generic')
 
         if kind in ['folder', 'folder-open']:
             # Providers are also seen as folders, so if the current folder


### PR DESCRIPTION
Older versions of QtAwesome, which are still in the Ubuntu repository, don't support the `fsa5` icons. This quick fix makes sure that this at least doesn't cause a crash, although whenever possible we should make sure that QtAwesome is up to date.